### PR TITLE
chore: add CODEOWNERS — core-browser owns this repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in this repo.
+* @browserbase/core-browser


### PR DESCRIPTION
Assigns [@browserbase/core-browser](https://github.com/orgs/browserbase/teams/core-browser) as default owner of everything here. The team now has write access (required for CODEOWNERS to be valid), and PRs will auto-request its review.

Note: this does **not** make code-owner review *required* — the rulesets keep `require_code_owner_review: false` on purpose, because the pipeline's auto-merging bot PRs (spec-sync, seal-tracking) would deadlock waiting for human approval. Auto-request only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)