### PR TITLE
docs: fix README Python examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ client = Browserbase(
 session = client.sessions.create(
     project_id=BROWSERBASE_PROJECT_ID,
 )
-```
-
 
 def run(playwright: Playwright) -> None:
     # Connect to the remote session
@@ -228,6 +226,8 @@ By default requests time out after 1 minute. You can configure this with a `time
 which accepts a float or an [`httpx.Timeout`](https://www.python-httpx.org/advanced/timeouts/#fine-tuning-the-configuration) object:
 
 ```python
+import httpx
+
 from browserbase import Browserbase
 
 # Configure the default for all requests:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+README = Path(__file__).parent.parent / "README.md"
+
+
+def python_blocks() -> list[str]:
+    return re.findall(r"```(?:py|python)\n(.*?)```", README.read_text(encoding="utf-8"), flags=re.DOTALL)
+
+
+def test_quickstart_is_a_complete_python_block() -> None:
+    quickstart = next(block for block in python_blocks() if "sync_playwright" in block)
+
+    assert "def run(playwright: Playwright) -> None:" in quickstart
+    assert 'if __name__ == "__main__":' in quickstart
+    compile(quickstart, str(README), "exec")
+
+
+def test_timeout_example_imports_httpx() -> None:
+    timeout_example = next(block for block in python_blocks() if "httpx.Timeout" in block)
+
+    assert "import httpx" in timeout_example
+    compile(timeout_example, str(README), "exec")


### PR DESCRIPTION
﻿## Summary

- keep the complete Playwright quickstart inside one Python code fence
- import `httpx` in the timeout example that uses `httpx.Timeout`
- add regression tests that compile both README snippets

## Why

The quickstart fence ended before the `run` function, making the rendered example incomplete, and the timeout snippet referenced `httpx` without importing it.

Fixes #176

## Testing

- `python -m pytest tests/test_readme.py -q` (2 passed)
- full suite: 1219 passed, 8 skipped; 4 pre-existing platform/environment failures tracked in #181
- full suite excluding only the four #181 cases: 1219 passed, 8 skipped
- `python -m ruff check .`
- `python -m ruff format --check tests/test_readme.py`
- `python -m pyright tests/test_readme.py`

Note: the repository-wide Ruff format check still reports two pre-existing example files (`examples/playwright_downloads.py` and `examples/playwright_proxy.py`).
