### PR TITLE
fix: support both TypeAliasType implementations

### DIFF
--- a/src/browserbase/_utils/_typing.py
+++ b/src/browserbase/_utils/_typing.py
@@ -51,7 +51,7 @@ def is_typevar(typ: type) -> bool:
     return type(typ) == TypeVar  # type: ignore
 
 
-_TYPE_ALIAS_TYPES: tuple[type[typing_extensions.TypeAliasType], ...] = (typing_extensions.TypeAliasType,)
+_TYPE_ALIAS_TYPES: tuple[type[object], ...] = (typing_extensions.TypeAliasType,)
 if sys.version_info >= (3, 12):
     _TYPE_ALIAS_TYPES = (*_TYPE_ALIAS_TYPES, typing.TypeAliasType)
 

--- a/tests/test_utils/test_typing.py
+++ b/tests/test_utils/test_typing.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import sys
+import typing
+import typing_extensions
 from typing import Generic, TypeVar, cast
 
-from browserbase._utils import extract_type_var_from_base
+from browserbase._utils import is_type_alias_type, extract_type_var_from_base
 
 _T = TypeVar("_T")
 _T2 = TypeVar("_T2")
 _T3 = TypeVar("_T3")
+ExtensionsAlias = typing_extensions.TypeAliasType("ExtensionsAlias", str)
+
+if sys.version_info >= (3, 12):
+    StdlibAlias = typing.TypeAliasType("StdlibAlias", str)
 
 
 class BaseGeneric(Generic[_T]): ...
@@ -22,6 +29,17 @@ class SubclassGenericMultipleTypeArgs(BaseGenericMultipleTypeArgs[_T, _T2, _T3])
 
 
 class SubclassDifferentOrderGenericMultipleTypeArgs(BaseGenericMultipleTypeArgs[_T2, _T, _T3]): ...
+
+
+def test_is_type_alias_type_from_typing_extensions() -> None:
+    assert is_type_alias_type(ExtensionsAlias)
+    assert not is_type_alias_type(str)
+
+
+if sys.version_info >= (3, 12):
+
+    def test_is_type_alias_type_from_typing() -> None:
+        assert is_type_alias_type(StdlibAlias)
 
 
 def test_extract_type_var() -> None:


### PR DESCRIPTION
﻿## Summary

- type the runtime alias-class tuple with the common `type[object]` base
- retain the existing `TypeIs` narrowing contract
- cover aliases created by both `typing_extensions` and Python 3.12's stdlib `typing`

## Why

On Python 3.12, `typing.TypeAliasType` and `typing_extensions.TypeAliasType` are distinct class objects. Appending the stdlib class to a tuple inferred as containing only the backport class made the repository's strict mypy check fail.

Fixes #178

## Testing

- `python -m pytest tests/test_utils/test_typing.py -q` (7 passed)
- `python -m mypy .` (success, 111 files)
- `python -m pyright src/browserbase/_utils/_typing.py tests/test_utils/test_typing.py`
- `python -m ruff check src/browserbase/_utils/_typing.py tests/test_utils/test_typing.py`
- full suite: 1219 passed, 8 skipped; 4 pre-existing Windows/environment failures tracked in #181
- full suite excluding only the four #181 cases: 1219 passed, 8 skipped
