### PR TITLE
fix: preserve empty query string values

### DIFF
--- a/src/browserbase/_qs.py
+++ b/src/browserbase/_qs.py
@@ -112,10 +112,9 @@ class Querystring:
                     f"Unknown array_format value: {array_format}, choose from {', '.join(get_args(ArrayFormat))}"
                 )
 
-        serialised = self._primitive_value_to_str(value)
-        if not serialised:
+        if value is None:
             return []
-        return [(key, serialised)]
+        return [(key, self._primitive_value_to_str(value))]
 
     def _primitive_value_to_str(self, value: PrimitiveData) -> str:
         # copied from httpx

--- a/tests/test_qs.py
+++ b/tests/test_qs.py
@@ -16,6 +16,7 @@ def test_empty() -> None:
 def test_basic() -> None:
     assert stringify({"a": 1}) == "a=1"
     assert stringify({"a": "b"}) == "a=b"
+    assert stringify({"a": ""}) == "a="
     assert stringify({"a": True}) == "a=true"
     assert stringify({"a": False}) == "a=false"
     assert stringify({"a": 1.23456}) == "a=1.23456"
@@ -40,6 +41,7 @@ def test_nested_brackets() -> None:
     assert unquote(stringify({"a": {"b": "c", "d": "e", "f": "g"}})) == "a[b]=c&a[d]=e&a[f]=g"
     assert unquote(stringify({"a": {"b": {"c": {"d": "e"}}}})) == "a[b][c][d]=e"
     assert unquote(stringify({"a": {"b": True}})) == "a[b]=true"
+    assert unquote(stringify({"a": {"b": ""}})) == "a[b]="
 
 
 @pytest.mark.parametrize("method", ["class", "function"])
@@ -59,6 +61,7 @@ def test_array_repeat() -> None:
     assert unquote(stringify({"a": {"b": [True, False]}})) == "a[b]=true&a[b]=false"
     assert unquote(stringify({"a": {"b": [True, False, None, True]}})) == "a[b]=true&a[b]=false&a[b]=true"
     assert unquote(stringify({"in": ["foo", {"b": {"c": ["d", "e"]}}]})) == "in=foo&in[b][c]=d&in[b][c]=e"
+    assert stringify({"in": [""]}) == "in="
 
 
 @pytest.mark.parametrize("method", ["class", "function"])


### PR DESCRIPTION
﻿## Summary

- omit only `None` scalar query values
- preserve supplied empty strings as `key=`
- cover top-level, nested, and repeated-array empty values

## Why

The serializer converted an empty string to `""` and then treated that valid serialized value as absent. APIs can distinguish a missing query key from a present-but-empty key, so callers need to be able to express both.

Fixes #179

## Testing

- `python -m pytest tests/test_qs.py -q` (11 passed)
- `python -m mypy src/browserbase/_qs.py`
- `python -m pyright src/browserbase/_qs.py tests/test_qs.py`
- `python -m ruff check src/browserbase/_qs.py tests/test_qs.py`
- `python -m ruff format --check src/browserbase/_qs.py tests/test_qs.py`
- full suite: 1217 passed, 8 skipped; 4 pre-existing Windows/environment failures tracked in #181
