### PR TITLE
test: make suite deterministic on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,26 @@ jobs:
 
       - name: Run tests
         run: ./scripts/test
+
+  windows-test:
+    timeout-minutes: 15
+    name: test (Windows)
+    runs-on: windows-latest
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: '0.10.2'
+
+      - name: Install dependencies
+        run: uv sync --python 3.12 --all-extras
+
+      - name: Start mock server
+        run: ./scripts/mock --daemon
+        shell: bash
+
+      - name: Run tests
+        run: uv run --python 3.12 pytest

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -979,8 +979,6 @@ class TestBrowserbase:
         assert response.http_request.headers.get("x-stainless-retry-count") == "42"
 
     def test_proxy_environment_variables(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Test that the proxy environment variables are set correctly
-        monkeypatch.setenv("HTTPS_PROXY", "https://example.org")
         # Delete in case our environment has any proxy env vars set
         monkeypatch.delenv("HTTP_PROXY", raising=False)
         monkeypatch.delenv("ALL_PROXY", raising=False)
@@ -989,6 +987,9 @@ class TestBrowserbase:
         monkeypatch.delenv("https_proxy", raising=False)
         monkeypatch.delenv("all_proxy", raising=False)
         monkeypatch.delenv("no_proxy", raising=False)
+        # Set this after deleting both casing variants. Windows environment
+        # variable names are case-insensitive.
+        monkeypatch.setenv("HTTPS_PROXY", "https://example.org")
 
         client = DefaultHttpxClient()
 
@@ -1919,8 +1920,6 @@ class TestAsyncBrowserbase:
         assert isinstance(platform, (str, OtherPlatform))
 
     async def test_proxy_environment_variables(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Test that the proxy environment variables are set correctly
-        monkeypatch.setenv("HTTPS_PROXY", "https://example.org")
         # Delete in case our environment has any proxy env vars set
         monkeypatch.delenv("HTTP_PROXY", raising=False)
         monkeypatch.delenv("ALL_PROXY", raising=False)
@@ -1929,6 +1928,9 @@ class TestAsyncBrowserbase:
         monkeypatch.delenv("https_proxy", raising=False)
         monkeypatch.delenv("all_proxy", raising=False)
         monkeypatch.delenv("no_proxy", raising=False)
+        # Set this after deleting both casing variants. Windows environment
+        # variable names are case-insensitive.
+        monkeypatch.setenv("HTTPS_PROXY", "https://example.org")
 
         client = DefaultAsyncHttpxClient()
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import base64
 import pathlib
 from typing import Any, Dict, List, Union, TypeVar, Iterable, Optional, cast
 from datetime import date, datetime
@@ -422,7 +423,7 @@ async def test_base64_file_input(use_async: bool) -> None:
 
     # pathlib.Path is automatically converted to base64
     assert await transform({"foo": SAMPLE_FILE_PATH}, TypedDictBase64Input, use_async) == {
-        "foo": "SGVsbG8sIHdvcmxkIQo="
+        "foo": base64.b64encode(SAMPLE_FILE_PATH.read_bytes()).decode("ascii")
     }  # type: ignore[comparison-overlap]
 
     # io instances are automatically converted to base64


### PR DESCRIPTION
﻿## Summary

- clear both proxy-variable casing variants before setting the value under test
- derive the expected base64 payload from the fixture's checked-out bytes
- add a Python 3.12 Windows CI job using the repository's Steady mock server

## Why

Windows treats environment variable names case-insensitively, so deleting lowercase `https_proxy` after setting uppercase `HTTPS_PROXY` removed the test value. Normal Git line-ending conversion also changes the fixture bytes from LF to CRLF, while the assertion hard-coded only the LF encoding.

Fixes #181

## Testing

- focused regression cases: 4 passed
- full Windows suite: 1221 passed, 8 skipped
- `python -m ruff check .`
- `python -m ruff format --check tests/test_client.py tests/test_transform.py`
- `python -m pyright tests/test_client.py tests/test_transform.py`

Known unrelated baselines: repository-wide Ruff format reports two existing example files, and Python 3.12 mypy reports the `TypeAliasType` issue fixed separately by #186.
