### PR TITLE
fix: handle empty suffix in removesuffix

### DIFF
--- a/src/browserbase/_utils/_utils.py
+++ b/src/browserbase/_utils/_utils.py
@@ -370,7 +370,7 @@ def removesuffix(string: str, suffix: str) -> str:
 
     Backport of `str.removesuffix` for Python < 3.9
     """
-    if string.endswith(suffix):
+    if suffix and string.endswith(suffix):
         return string[: -len(suffix)]
     return string
 

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from browserbase._utils import removeprefix, removesuffix
+
+
+@pytest.mark.parametrize(
+    ("string", "prefix"),
+    [
+        ("browserbase", "browser"),
+        ("browserbase", "base"),
+        ("browserbase", ""),
+        ("", ""),
+    ],
+)
+def test_removeprefix_matches_stdlib(string: str, prefix: str) -> None:
+    assert removeprefix(string, prefix) == string.removeprefix(prefix)
+
+
+@pytest.mark.parametrize(
+    ("string", "suffix"),
+    [
+        ("browserbase", "base"),
+        ("browserbase", "browser"),
+        ("browserbase", ""),
+        ("", ""),
+    ],
+)
+def test_removesuffix_matches_stdlib(string: str, suffix: str) -> None:
+    assert removesuffix(string, suffix) == string.removesuffix(suffix)


### PR DESCRIPTION
﻿## Summary

- guard suffix removal against the empty-suffix slicing edge case
- compare both compatibility helpers with the Python standard library
- cover matching, non-matching, empty-affix, and empty-input cases

## Why

`string[:-len(suffix)]` becomes `string[:0]` for an empty suffix, returning an empty string instead of preserving the input as `str.removesuffix("")` does.

Fixes #182

## Testing

- `python -m pytest tests/test_utils/test_utils.py -q` (8 passed)
- `python -m mypy src/browserbase/_utils/_utils.py tests/test_utils/test_utils.py`
- `python -m pyright src/browserbase/_utils/_utils.py tests/test_utils/test_utils.py`
- `python -m ruff check src/browserbase/_utils/_utils.py tests/test_utils/test_utils.py`
- `python -m ruff format --check src/browserbase/_utils/_utils.py tests/test_utils/test_utils.py`
- full suite: 1225 passed, 8 skipped; 4 pre-existing Windows/environment failures fixed separately by #189
- full suite excluding only the four #189 cases: 1225 passed, 8 skipped
